### PR TITLE
FIX: Fix clang failing to compile due to variable shadowing

### DIFF
--- a/easyloggingpp/easylogging++.h
+++ b/easyloggingpp/easylogging++.h
@@ -3167,26 +3167,26 @@ namespace base {
             if (filePath.size() < resolvedFilename.size()) {
                 base::utils::File::createPath(filePath);
             }
-            auto create = [&](Level level) {
+            auto create = [&](Level llevel) {
                 base::LogStreamsReferenceMap::iterator filestreamIter = m_logStreamsReference->find(resolvedFilename);
                 base::type::fstream_t* fs = nullptr;
                 if (filestreamIter == m_logStreamsReference->end()) {
                     // We need a completely new stream, nothing to share with
                     fs = base::utils::File::newFileStream(resolvedFilename);
-                    m_filenameMap.insert(std::make_pair(level, resolvedFilename));
-                    m_fileStreamMap.insert(std::make_pair(level, base::FileStreamPtr(fs)));
+                    m_filenameMap.insert(std::make_pair(llevel, resolvedFilename));
+                    m_fileStreamMap.insert(std::make_pair(llevel, base::FileStreamPtr(fs)));
                     m_logStreamsReference->insert(std::make_pair(resolvedFilename, base::FileStreamPtr(m_fileStreamMap.at(level))));
                 } else {
                     // Woops! we have an existing one, share it!
-                    m_filenameMap.insert(std::make_pair(level, filestreamIter->first));
-                    m_fileStreamMap.insert(std::make_pair(level, base::FileStreamPtr(filestreamIter->second)));
+                    m_filenameMap.insert(std::make_pair(llevel, filestreamIter->first));
+                    m_fileStreamMap.insert(std::make_pair(llevel, base::FileStreamPtr(filestreamIter->second)));
                     fs = filestreamIter->second.get();
                 }
                 if (fs == nullptr) {
                     // We display bad file error from newFileStream()
                     ELPP_INTERNAL_ERROR("Setting [TO_FILE] of ["
-                                        << LevelHelper::convertToString(level) << "] to FALSE", false);
-                    setValue(level, false, &m_toFileMap);
+                                        << LevelHelper::convertToString(llevel) << "] to FALSE", false);
+                    setValue(llevel, false, &m_toFileMap);
                 }
             };
             // If we dont have file conf for any level, create it for Level::Global first


### PR DESCRIPTION
clang failes to compile easylogging++ header on macOS due to:

> Declaration shadows a local variable

Temporary fix is to rename the local variable
