### PR TITLE
Add MicroUI External

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "serial"]
 	path = serial
 	url = https://github.com/wjwwood/serial.git
+[submodule "microui"]
+	path = microui
+	url = https://github.com/rxi/microui


### PR DESCRIPTION
Adds [MicroUI](https://github.com/rxi/microui) as a submodule.
This library is used in the WIP interface functionality for SplashKit.